### PR TITLE
Configure static export for Next.js

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,10 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- enable static export output in the Next.js configuration
- mark images as unoptimized to support the export target

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e10fa11a80833082614a5e0deaaff7