### PR TITLE
Configure Next.js base path for GitHub Pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,16 @@
 import type { NextConfig } from "next";
 
+const repo = process.env.NEXT_PUBLIC_GITHUB_REPOSITORY ?? "";
+const isProd = process.env.NODE_ENV === "production";
+const basePath = isProd && repo ? `/${repo}` : "";
+
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
   output: "export",
+  basePath,
+  assetPrefix: basePath ? `${basePath}/` : undefined,
+  trailingSlash: true,
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary
- derive the GitHub Pages repository base path from NEXT_PUBLIC_GITHUB_REPOSITORY
- apply the base path to Next.js basePath and assetPrefix for production exports
- enable trailing slashes to stabilize static asset URLs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e11079f61c833096a6e64fc981c00e