### PR TITLE
feat: add calm MUI theme

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,58 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { CssBaseline, ThemeProvider, createTheme } from "@mui/material";
+
+const theme = createTheme({
+  palette: {
+    mode: "light",
+    background: {
+      default: "#f4f5f7",
+      paper: "#ffffff",
+    },
+    primary: {
+      main: "#4f6d7a",
+      light: "#6b8794",
+      dark: "#2f4d5a",
+      contrastText: "#ffffff",
+    },
+    secondary: {
+      main: "#8aa0b3",
+      contrastText: "#1f2933",
+    },
+    text: {
+      primary: "#1f2933",
+      secondary: "#52606d",
+    },
+  },
+  shape: {
+    borderRadius: 12,
+  },
+  components: {
+    MuiButton: {
+      defaultProps: {
+        disableElevation: true,
+      },
+      styleOverrides: {
+        root: {
+          boxShadow: "none",
+          borderRadius: 14,
+          textTransform: "none",
+          fontWeight: 600,
+          transition: "background-color 0.2s ease, color 0.2s ease",
+          "&:hover": {
+            boxShadow: "none",
+          },
+        },
+      },
+    },
+  },
+});
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -546,9 +546,10 @@ export default function Home() {
         <Box
           mb={{ xs: 2.5, sm: 4 }}
           p={{ xs: 2, sm: 3 }}
-          bgcolor="#e3f2fd"
+          bgcolor="background.paper"
           borderRadius={2}
-          boxShadow={1}
+          border="1px solid"
+          borderColor="divider"
         >
           <Typography variant="h6" gutterBottom>
             目標の進捗状況
@@ -610,7 +611,8 @@ export default function Home() {
               borderRadius: 2,
               mb: { xs: 1.5, sm: 2 },
               bgcolor: "background.paper",
-              boxShadow: { xs: 1, sm: 0 },
+              border: "1px solid",
+              borderColor: "divider",
             }}
             secondaryAction={
               <IconButton


### PR DESCRIPTION
## Summary
- add a global MUI theme with a calm palette and button overrides
- adjust goal and todo list styling to match the flat theme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1134637b0833082ced05f3aa85948